### PR TITLE
Update README to contain more explicit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The tool does not, and you need to
 </pre>
 * Change project dependencies from `vaadin-server` to `vaadin-compatibility-server`
 * Change project dependencies from `vaadin-client-compiled` to `vaadin-compatibility-client-compiled` if you are using `com.vaadin.DefaultWidgetSet`
-* Change project widget set from `com.vaadin.DefaultWidgetSet` to `com.vaadin.v7.Vaadin7WidgetSet` if you are using `DefaultWidgetset`. This is typically declared in @Widgetset annotation in your UI or in web.xml file.
+* Change project widget set from `com.vaadin.DefaultWidgetSet` to `com.vaadin.v7.Vaadin7WidgetSet` if you are using `DefaultWidgetset`. This is typically declared with a @Widgetset annotation in your UI or in the web.xml file.
 * Recompile your widget set if you are not using `com.vaadin.DefaultWidgetSet`
 
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ The tool does not, and you need to
 
 </pre>
 * Change project dependencies from `vaadin-server` to `vaadin-compatibility-server`
-* Change project dependencies from `vaadin-client-compiled` to `vaadin-compatibility-client-compiled` if you are using `DefaultWidgetSet`
-* Change project widget set from `DefaultWidgetSet` to `Vaadin7WidgetSet` if you are using `DefaultWidgetset`
-* Recompile your widget set if you are not using `DefaultWidgetSet`
+* Change project dependencies from `vaadin-client-compiled` to `vaadin-compatibility-client-compiled` if you are using `com.vaadin.DefaultWidgetSet`
+* Change project widget set from `com.vaadin.DefaultWidgetSet` to `com.vaadin.v7.Vaadin7WidgetSet` if you are using `DefaultWidgetset`. This is typically declared in @Widgetset annotation in your UI or in web.xml file.
+* Recompile your widget set if you are not using `com.vaadin.DefaultWidgetSet`
 
 


### PR DESCRIPTION
There is no way one could know that Vaadin7WidgetSet is in special v7 package, so README should contain fully qualified names for widgetsets.